### PR TITLE
Create inline interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ $ gem install rpn-calculator-0.3.0.gem
 directly as shown in the next step.
 #### Run
 
+##### As a CLI Tool
+
 If you installed the tool as a Gem, you should be able to call the binary directly:
 
 ```bash
@@ -91,7 +93,30 @@ $ cd rpn-calculator
 $ ./bin/rpn-calculator
 ```
 
-#### Sample Input/Output
+##### As an imported module from your code
+
+```ruby
+require 'rpn-calculator'
+
+# calculus is a RPNCalculator::Result::Operation
+calculus = RPNCalculator.calculate('1 2 3 4 +-+')
+# result can be an array with the result of the operation or an error message
+# for an invalid expression. The result is an array where the only element
+# is the actual result if the expression was complete
+result = calculus.valid? ? calculus.result : calculus.error
+# result => [-4.0]
+
+# Array size is greater than one when an expression is correct but incomplete
+calculus = RPNCalculator.calculate('10 1 2 3 4 +-+')
+# calculus.result => ['10', -4.0]
+
+# if the expression has errors
+calculus = RPNCalculator.calculate('1 2 3 4 +-+/')
+# calculus.valid? => false
+# calculus.error => "Invalid operation: -4.0 /"
+```
+
+#### Sample CLI Input/Output
 
 ```bash
 $ rpn-calculator

--- a/bin/rpn-calculator
+++ b/bin/rpn-calculator
@@ -2,4 +2,4 @@
 
 require 'rpn-calculator'
 
-RPNCalculator.start
+RPNCalculator.start_cli_tool

--- a/lib/rpn-calculator.rb
+++ b/lib/rpn-calculator.rb
@@ -10,20 +10,23 @@ module RPNCalculator
     '/' => Operation::Division
   }.freeze
   ALLOWED_OPERATORS       = OPERATION_CLASSES.keys.freeze
-  INVALID_ARGUMENTS_REGEX = /[^\d\s\.#{Regexp.quote(ALLOWED_OPERATORS.join)}]/.freeze
+  INVALID_ARGUMENTS_REGEX = /[^\d\s\.#{Regexp.quote(ALLOWED_OPERATORS.join)}]/
+  OPERATION_PROCESSOR     = OperationProcessor.new(
+    OPERATION_CLASSES,
+    Input::Validator.new(INVALID_ARGUMENTS_REGEX),
+    Input::Parser.new(ALLOWED_OPERATORS)
+  ).freeze
 
   module_function
 
-  def start
-    operation_processor = OperationProcessor.new(
-      OPERATION_CLASSES,
-      Input::Validator.new(INVALID_ARGUMENTS_REGEX),
-      Input::Parser.new(ALLOWED_OPERATORS)
-    )
-
+  def start_cli_tool
     # Here is where we could read and write to another input
     # using stdin and stdout by default
-    processor = IoProcessor.new(IoInterface::Standard.new, operation_processor)
+    processor = CLI.new(IoInterface::Standard.new, OPERATION_PROCESSOR)
     processor.start
+  end
+
+  def calculate(expression)
+    OPERATION_PROCESSOR.process(expression)
   end
 end

--- a/lib/rpn-calculator/cli.rb
+++ b/lib/rpn-calculator/cli.rb
@@ -1,5 +1,5 @@
 module RPNCalculator
-  class IoProcessor
+  class CLI
     def initialize(io_interface, operation_processor)
       @io_interface = io_interface
       @input_stack  = []
@@ -7,8 +7,8 @@ module RPNCalculator
     end
 
     def start
-      while (input = io_interface.read_input)
-        processor_result = operation_processor.process(input_stack, input)
+      while (input_expression = io_interface.read_input)
+        processor_result = operation_processor.process(input_expression, input_stack)
 
         if processor_result.valid?
           print_result_array(processor_result.result)

--- a/lib/rpn-calculator/operation_processor.rb
+++ b/lib/rpn-calculator/operation_processor.rb
@@ -8,11 +8,11 @@ module RPNCalculator
     end
 
     # Refator needed, process should receive parsed input
-    def process(previous_operations, input)
-      validator_result = input_validator.validate(input)
+    def process(input_expression, previous_operations = [])
+      validator_result = input_validator.validate(input_expression)
       return Result::Processor.new([], validator_result.error) unless validator_result.valid?
 
-      parser_result = input_parser.parse(input)
+      parser_result = input_parser.parse(input_expression)
       return Result::Processor.new([], parser_result.error) unless parser_result.valid?
 
       process_operations(previous_operations + parser_result.parsed_elements)

--- a/spec/rpn-calculator/cli_spec.rb
+++ b/spec/rpn-calculator/cli_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe RPNCalculator::IoProcessor do
+RSpec.describe RPNCalculator::CLI do
   let(:io_interface) { double(:test_io_interface) }
   let(:operation_processor) do
     RPNCalculator::OperationProcessor.new(

--- a/spec/rpn-calculator/operation_processor_spec.rb
+++ b/spec/rpn-calculator/operation_processor_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe RPNCalculator::OperationProcessor do
       let(:validator_result) { double(:validator_result, valid?: false, error: 'Invalid input') }
 
       it 'returns an invalid processor result' do
-        processor_result = subject.process([], 'some invalid input')
+        processor_result = subject.process('some invalid input')
         expect(processor_result).not_to be_valid
       end
 
       it 'returns a processor result with an error message' do
-        processor_result = subject.process([], 'some invalid input')
+        processor_result = subject.process('some invalid input')
         expect(processor_result.error).to eq('Invalid input')
       end
     end
@@ -43,12 +43,12 @@ RSpec.describe RPNCalculator::OperationProcessor do
       let(:parser_result)    { double(:parser_result, valid?: false, error: 'Invalid input after parsing') }
 
       it 'returns an invalid processor result' do
-        processor_result = subject.process([], 'invalid even after char validation')
+        processor_result = subject.process('invalid even after char validation')
         expect(processor_result).not_to be_valid
       end
 
       it 'returns a processor result with an error message' do
-        processor_result = subject.process([], 'some invalid input')
+        processor_result = subject.process('some invalid input')
         expect(processor_result.error).to eq('Invalid input after parsing')
       end
     end
@@ -60,20 +60,20 @@ RSpec.describe RPNCalculator::OperationProcessor do
         it 'returns a valid operation result' do
           allow(parser_result).to receive(:parsed_elements).and_return(valid_input.split(' '))
 
-          processor_result = subject.process([], "Parsing is mocked so don't mind this")
+          processor_result = subject.process("Parsing is mocked so don't mind this")
           expect(processor_result).to be_valid
         end
 
         it 'returns a valid operation result with the correct operation value' do
           allow(parser_result).to receive(:parsed_elements).and_return(valid_input.split(' '))
 
-          processor_result = subject.process([], "Parsing is mocked so don't mind this")
+          processor_result = subject.process("Parsing is mocked so don't mind this")
           expect(processor_result.result).to eq([4.0])
         end
 
         it 'returns correct operation value plus remaining elements in the stack' do
           allow(parser_result).to receive(:parsed_elements).and_return((valid_input + ' 10').split(' '))
-          processor_result = subject.process([], "Parsing is mocked so don't mind this")
+          processor_result = subject.process("Parsing is mocked so don't mind this")
           expect(processor_result.result).to eq([4.0, '10'])
         end
       end
@@ -84,20 +84,20 @@ RSpec.describe RPNCalculator::OperationProcessor do
         it 'returns a valid operation result' do
           allow(parser_result).to receive(:parsed_elements).and_return(valid_input.split(' '))
 
-          processor_result = subject.process([], "Parsing is mocked so don't mind this")
+          processor_result = subject.process("Parsing is mocked so don't mind this")
           expect(processor_result).to be_valid
         end
 
         it 'returns a valid operation result with the correct operation value' do
           allow(parser_result).to receive(:parsed_elements).and_return(valid_input.split(' '))
 
-          processor_result = subject.process([], "Parsing is mocked so don't mind this")
+          processor_result = subject.process("Parsing is mocked so don't mind this")
           expect(processor_result.result).to eq([-2.0])
         end
 
         it 'returns correct operation value plus remaining elements in the stack' do
           allow(parser_result).to receive(:parsed_elements).and_return((valid_input + ' 10').split(' '))
-          processor_result = subject.process([], "Parsing is mocked so don't mind this")
+          processor_result = subject.process("Parsing is mocked so don't mind this")
           expect(processor_result.result).to eq([-2.0, '10'])
         end
       end
@@ -108,14 +108,14 @@ RSpec.describe RPNCalculator::OperationProcessor do
         it 'returns an invalid operation result' do
           allow(parser_result).to receive(:parsed_elements).and_return(invalid_input.split(' '))
 
-          processor_result = subject.process([], "Parsing is mocked so don't mind this")
+          processor_result = subject.process("Parsing is mocked so don't mind this")
           expect(processor_result).not_to be_valid
         end
 
         it 'returns the error for an invalid operation' do
           allow(parser_result).to receive(:parsed_elements).and_return(invalid_input.split(' '))
 
-          processor_result = subject.process([], "Parsing is mocked so don't mind this")
+          processor_result = subject.process("Parsing is mocked so don't mind this")
           expect(processor_result.error).to eq('Invalid operation: 4.0 *')
         end
 
@@ -123,7 +123,7 @@ RSpec.describe RPNCalculator::OperationProcessor do
           multiple_input_errors = invalid_input + ' + 4 / /'
           allow(parser_result).to receive(:parsed_elements).and_return(multiple_input_errors.split(' '))
 
-          processor_result = subject.process([], "Parsing is mocked so don't mind this")
+          processor_result = subject.process("Parsing is mocked so don't mind this")
           expect(processor_result.error).to eq('Invalid operation: 4.0 *')
         end
       end


### PR DESCRIPTION
Create an inline interface so expressions can be resolved within code. `RPNCalculator.calculate('RPN expression')` will return the result of the calculus or all the elements in the stack if operations are missing.